### PR TITLE
Added Ruby 3.3 to CI and removed 2.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os:   [ 'ubuntu', 'macos' ]
-        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2' ]
+        ruby: [ '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3' ]
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1

--- a/youplot.gemspec
+++ b/youplot.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'A command line tool for Unicode Plotting'
   spec.homepage      = 'https://github.com/red-data-tools/YouPlot'
   spec.license       = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.4.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.5.0')
 
   spec.files         = Dir['*.{md,txt}', '{lib,exe}/**/*']
   spec.bindir        = 'exe'


### PR DESCRIPTION
Ruby 3.3 has been released.
Instead of adding Ruby 3.3 to CI, remove 2.4.
Ruby 2.4 Thanks for a long time.